### PR TITLE
Changed the link in README to the blog post to the GitHub intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 ```
 
 [coc]: http://tinyurl.com/tulip-conduct "Code of Conduct"
-[post]: http://www.jneen.net/posts/2015-07-29-tulip-language-updated "Tulip"
+[intro]: https://github.com/tulip-lang/tulip/blob/master/doc/intro.md#readme
 
-[Tulip is a language!][post]
+[Tulip is a language!][intro]
 
 ## Why Tulip?
 
@@ -19,7 +19,7 @@
 * Flexible actor-based concurrency model with no shared state (lifted from Erlang, really)
 * A diverse core team, and a founder who is not cis, straight, or a man. Also a [real, enforced code of conduct][coc], and a pretty-flower aesthetic.
 
-For more details, please read the blog post linked above.
+For more details, please read the intro linked above.
 
 ## Contributing
 


### PR DESCRIPTION
Just a quick change to the README; the blog post recommends going to the GitHub intro anyways.

I won't be offended if anyone else wants to make this their own contribution.
